### PR TITLE
Make handler class callable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ cfnlambda
 
 :code:`cfnlambda` provides an abstract base class to make it easier to implement
 `AWS CloudFormation custom resources`_. It was forked from Gene Wood's
-`library of the same name`_, which provides lower-level functions and 
+`library of the same name`_, which provides lower-level functions and
 decorators for the same purpose.
 
 The :code:`CloudFormationCustomResource` class requires a child class to implement
@@ -22,15 +22,15 @@ Quickstart
 	
     class Adder(CloudFormationCustomResource):
         def create(self):
-            sum = (float(self.resource_properties['key1']) + 
+            sum = (float(self.resource_properties['key1']) +
                    float(self.resource_properties['key2']))
             return {'sum': sum}
-        
+
         update = create
-        
+
         def delete(self):
             pass
-    
+
     handle = Adder()
 
 ::
@@ -41,13 +41,13 @@ Quickstart
         def create(self):
             client = self.get_boto3_client('service-name')
             # use client
-        
+
         def update(self):
             # create and use client
-        
+
         def delete(self):
             # create and use client
-    
+
     handle = AWSServiceUnsupportedByCF()
 
 ::
@@ -56,9 +56,9 @@ Quickstart
 	
     class ExternalServer(CloudFormationCustomResource):
         DISABLE_PHYSICAL_RESOURCE_ID_GENERATION = True # get this from server
-        
+
         # create_server, update_server, terminate_server methods implemented here
-        
+
         def create(self):
             properties:
             response = self.create_server(properties=self.resource_properties)
@@ -66,24 +66,24 @@ Quickstart
                 raise Exception('server creation failed')
             self.physical_resource_id = response.hostname
             return {'IP': response.ip}
-        
+
         def update(self):
             response = self.update_server(hostname=self.physical_resource_id, properties=self.resource_properties)
             if response.status != 200:
                 raise Exception('server update failed')
             return {'IP': response.ip}
-        
+
         def delete(self):
             response = self.terminate_server(hostname=self.physical_resource_id)
             if response.status != 200:
                 raise Exception('server termination failed')
-    
+
     handle = ExternalServer()
 
 The :code:`handle` method on :code:`CloudFormationCustomResource` does a few things. It logs
 the event and context, populates the class fields, generates a physical resource id
 for the resource, and calls the :code:`validate` and :code:`populate` methods that the child class
-can override. Then, it calls the :code:`create`, :code:`update`, or :code:`delete` method as 
+can override. Then, it calls the :code:`create`, :code:`update`, or :code:`delete` method as
 appropriate, adds any returned dictionary to the :code:`resource_outputs` dict, or, in
 case of an exception, sets the status to FAILED. It then cleans up and returns the
 result to CloudFormation.
@@ -104,13 +104,13 @@ be deleted upon a successful stack deletion. If an exception is thrown during
 stack deletion, the logs will always be retained to facilitate troubleshooting.
 NOTE: this is not intended for use when multiple stacks access the same function.
 
-Finally, the custom resource will not report a status of FAILED when a stack 
+Finally, the custom resource will not report a status of FAILED when a stack
 DELETE is attempted. This will prevent a CloudFormation stack from getting stuck
 in a DELETE_FAILED state. One side effect of this is that if your AWS Lambda
-function throws an exception while trying to process a stack deletion, though 
+function throws an exception while trying to process a stack deletion, though
 the stack will show a status of DELETE_COMPLETE, there could still be resources
 which your AWS Lambda function created which have not been deleted. This will be
-noted in the logs. To disable this feature, set HIDE_STACK_DELETE_FAILURE 
+noted in the logs. To disable this feature, set HIDE_STACK_DELETE_FAILURE
 class field to False.
 
 How to contribute

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,7 @@ Quickstart
         def delete(self):
             pass
     
-    def handle(event, context):
-        Adder().handle(event, context)
+    handle = Adder()
 
 ::
 
@@ -49,8 +48,7 @@ Quickstart
         def delete(self):
             # create and use client
     
-    def handle(event, context):
-        AWSServiceUnsupportedByCF().handle(event, context)
+    handle = AWSServiceUnsupportedByCF()
 
 ::
 
@@ -80,8 +78,7 @@ Quickstart
             if response.status != 200:
                 raise Exception('server termination failed')
     
-    def handle(event, context):
-        ExternalServer().handle(event, context)
+    handle = ExternalServer()
 
 The :code:`handle` method on :code:`CloudFormationCustomResource` does a few things. It logs
 the event and context, populates the class fields, generates a physical resource id

--- a/cfnlambda.py
+++ b/cfnlambda.py
@@ -14,21 +14,21 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class CloudFormationCustomResource(object):
     """Base class for CloudFormation custom resource classes.
-    
+
     To create a handler for a custom resource in CloudFormation, simply create a
     child class (say, MyCustomResource), implement the methods specified below,
     and implement the handler function:
-    
+
     def handler(event, context):
         MyCustomResource().handle(event, context)
-    
+
     The child class does not need to have a constructor. In this case, the resource
-    type name, which is validated by handle() method, is 'Custom::' + the child 
+    type name, which is validated by handle() method, is 'Custom::' + the child
     class name. The logger also uses the child class name. If either of these need
     to be different, they can be provided to the parent constructor. The resource
     type passed to the parent constructor can be a string or a list of strings, if
     the child class is capable of processing multiple resource types.
-    
+
     Child classes must implement the create(), update(), and delete() methods.
     Each of these methods can indicate success or failure in one of two ways:
     * Simply return or raise an exception
@@ -39,11 +39,11 @@ class CloudFormationCustomResource(object):
     that then will be available in CloudFormation. If the return value of the function
     is a dict, that is merged into resource_outputs. If it is not a dict, the value
     is stored under the 'result' key.
-    
+
     Child classes may implement validate() and/or populate(). validate() should return
     True if self.resource_properties is valid. populate() can transfer the contents of
     self.resource_properties into object fields, if this is not done by validate().
-    
+
     The class provides methods get_boto3_client() and get_boto3_resource() that cache
     the clients/resources in the class, reducing overhead in the Lambda invocations.
     These also rely on the get_boto3_session() method, which in turn uses
@@ -51,12 +51,12 @@ class CloudFormationCustomResource(object):
     testing. Similarly, BOTO3_CLIENT_FACTORY and BOTO3_RESOURCE_FACTORY, both of which
     can be set to callables that take a session and a name, can be set to override
     client and resource creation.
-    
+
     Some hooks are provided to override behavior. The first four are instance fields,
     since they may be set to functions that rely on instance fields. The last
     is a class field, since it is called by a class method.
     * finish_function, normally set to CloudFormationCustomResource.cfn_response, takes
-        as input the custom resource object and deals with sending the response and 
+        as input the custom resource object and deals with sending the response and
         cleaning up.
     * send_function, used within CloudFormationCustomResource.cfn_response, takes as
         input the custom resource object, a url, and the response_content dictionary.
@@ -104,101 +104,101 @@ class CloudFormationCustomResource(object):
     """
     DELETE_LOGS_ON_STACK_DELETION = False
     HIDE_STACK_DELETE_FAILURE = True
-    
+
     DISABLE_PHYSICAL_RESOURCE_ID_GENERATION = False
     PHYSICAL_RESOURCE_ID_MAX_LEN = 128
-    
+
     STATUS_SUCCESS = 'SUCCESS'
     STATUS_FAILED = 'FAILED'
-    
+
     REQUEST_CREATE = 'Create'
     REQUEST_DELETE = 'Delete'
     REQUEST_UPDATE = 'Update'
-    
+
     BASE_LOGGER_LEVEL = None
-    
+
     def __init__(self, resource_type=None, logger=None):
         import logging
         if logger:
             self.logger = logger
         else:
             self.logger = logging.getLogger(self.__class__.__name__)
-        
+
         self._base_logger = logging.getLogger('CFCustomResource')
         if self.BASE_LOGGER_LEVEL:
             self._base_logger.setLevel(self.BASE_LOGGER_LEVEL)
-        
+
         if not resource_type:
             resource_type = self.__class__.__name__
-        
+
         def process_resource_type(resource_type):
             if not (resource_type.startswith('Custom::') or resource_type == 'AWS::CloudFormation::CustomResource'):
                 resource_type = 'Custom::' + resource_type
             return resource_type
-        
+
         if isinstance(resource_type, (list, tuple)):
             resource_type = [process_resource_type(rt) for rt in resource_type]
         elif isinstance(resource_type, basestring):
             resource_type = process_resource_type(resource_type)
-        
+
         self.resource_type = resource_type
-        
+
         self.event = None
         self.context = None
-        
+
         self.request_resource_type = None
         self.request_type = None
         self.response_url = None
         self.stack_id = None
         self.request_id = None
-        
+
         self.logical_resource_id = None
         self.physical_resource_id = None
         self.resource_properties = None
         self.old_resource_properties = None
-        
+
         self.status = None
         self.failure_reason = None
         self.resource_outputs = {}
-        
+
         self.finish_function = self.cfn_response
         self.send_response_function = self.send_response
-        
+
         self.generate_unique_id_prefix_function = None
         self.generate_physical_resource_id_function = self.generate_unique_id
-        
+
     def validate_resource_type(self, resource_type):
-        """Return True if resource_type is valid""" 
+        """Return True if resource_type is valid"""
         if isinstance(self.resource_type, (list, tuple)):
             return resource_type in self.resource_type
         return resource_type == self.resource_type
-    
+
     def validate(self):
         """Return True if self.resource_properties is valid."""
         return True
-    
+
     def populate(self):
         """Populate fields from self.resource_properties and self.old_resource_properties,
         if this is not done in validate()"""
         pass
-    
+
     def create(self):
         raise NotImplementedError
-    
+
     def update(self):
         raise NotImplementedError
-    
+
     def delete(self):
         raise NotImplementedError
-    
+
     BOTO3_SESSION_FACTORY = None
     BOTO3_CLIENT_FACTORY = None
     BOTO3_RESOURCE_FACTORY = None
-    
+
     BOTO3_SESSION = None
     BOTO3_CLIENTS = {}
     BOTO3_RESOURCES = {}
-    
+
     @classmethod
     def get_boto3_session(cls):
         if cls.BOTO3_SESSION is None:
@@ -208,7 +208,7 @@ class CloudFormationCustomResource(object):
                 import boto3
                 cls.BOTO3_SESSION = boto3.session.Session()
         return cls.BOTO3_SESSION
-    
+
     @classmethod
     def get_boto3_client(cls, name):
         if name not in cls.BOTO3_CLIENTS:
@@ -218,7 +218,7 @@ class CloudFormationCustomResource(object):
                 client = cls.get_boto3_session().client(name)
             cls.BOTO3_CLIENTS[name] = client
         return cls.BOTO3_CLIENTS[name]
-    
+
     @classmethod
     def get_boto3_resource(cls, name):
         if name not in cls.BOTO3_RESOURCES:
@@ -250,44 +250,44 @@ class CloudFormationCustomResource(object):
                 else:
                     d[field] = repr(value)
         self._base_logger.info('LambdaContext: %s' % json.dumps(plainify(context)))
-        
+
         self.event = event
         self.context = context
-        
+
         self.request_resource_type = event['ResourceType']
         self.request_type = event['RequestType']
         self.response_url = event['ResponseURL']
         self.stack_id = event['StackId']
         self.request_id = event['RequestId']
-        
+
         self.logical_resource_id = event['LogicalResourceId']
         self.physical_resource_id = event.get('PhysicalResourceId')
         self.resource_properties = event.get('ResourceProperties', {})
         self.old_resource_properties = event.get('OldResourceProperties')
-        
+
         self.status = None
         self.failure_reason = None
         self.resource_outputs = {}
-        
+
         try:
             if not self.validate_resource_type(self.request_resource_type):
                 raise Exception('invalid resource type')
-        
+
             if not self.validate():
                 pass
-            
+
             if not self.physical_resource_id and not self.DISABLE_PHYSICAL_RESOURCE_ID_GENERATION:
                 self.physical_resource_id = self.generate_physical_resource_id_function(max_len=self.PHYSICAL_RESOURCE_ID_MAX_LEN)
-            
+
             self.populate()
-            
+
             outputs = getattr(self, self.request_type.lower())()
-            
+
             if outputs:
                 if not isinstance(outputs, dict):
                     outputs = {'result': outputs}
                 self.resource_outputs.update(outputs)
-            
+
             if not self.status:
                 self.status = self.STATUS_SUCCESS
         except Exception, e:
@@ -298,7 +298,7 @@ class CloudFormationCustomResource(object):
             if self.failure_reason:
                 self._base_logger.error(str(self.failure_reason))
             self._base_logger.debug(traceback.format_exc())
-            
+
         if self.request_type == self.REQUEST_DELETE:
             if self.status == self.STATUS_FAILED and self.HIDE_STACK_DELETE_FAILURE:
                 message = (
@@ -317,32 +317,32 @@ class CloudFormationCustomResource(object):
                 logs_client = self.get_boto3_client('logs')
                 logs_client.delete_log_group(
                     logGroupName=context.log_group_name)
-        
+
         self.finish_function(self)
-    
+
     def generate_unique_id(self, prefix=None, separator='-', max_len=None):
         """Generate a unique id similar to how CloudFormation generates
         physical resource ids"""
         import random
         import string
-        
+
         if prefix is None:
             if self.generate_unique_id_prefix_function:
                 prefix = self.generate_unique_id_prefix_function()
             else:
                 prefix = ''
-    
+
         stack_id = self.stack_id.split(':')[-1]
         if '/' in stack_id:
             stack_id = stack_id.split('/')[1]
         stack_id = stack_id.replace('-', '')
-    
+
         logical_resource_id = self.logical_resource_id
-    
+
         len_of_rand = 12
-        
+
         rand = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(len_of_rand))
-        
+
         if max_len:
             max_len = max_len-len(prefix)
             len_of_parts = max_len - len_of_rand - 2 * len(separator)
@@ -359,7 +359,7 @@ class CloudFormationCustomResource(object):
             logical_id=logical_resource_id,
             rand=rand,
             )
-    
+
     @classmethod
     def send_response(cls, resource, url, response_content):
         import httplib, json
@@ -367,20 +367,20 @@ class CloudFormationCustomResource(object):
             import requests
         except:
             from botocore.vendored import requests
-        
+
         put_response = requests.put(resource.response_url,
                                     data=json.dumps(response_content))
         body_text = ""
         if put_response.status_code // 100 != 2:
             body_text = "\n" + put_response.text
         resource._base_logger.debug("Status code: %s %s%s" % (put_response.status_code, httplib.responses[put_response.status_code], body_text))
-            
+
         return put_response
-    
+
     @classmethod
     def cfn_response(cls, resource):
-        import json, traceback   
-        
+        import json, traceback
+
         physical_resource_id = resource.physical_resource_id
         if physical_resource_id is None:
             physical_resource_id = resource.context.log_stream_name

--- a/cfnlambda.py
+++ b/cfnlambda.py
@@ -119,7 +119,6 @@ class CloudFormationCustomResource(object):
     
     def __init__(self, resource_type=None, logger=None):
         import logging
-        import boto3
         if logger:
             self.logger = logger
         else:
@@ -229,7 +228,10 @@ class CloudFormationCustomResource(object):
                 resource = cls.get_boto3_session().resource(name)
             cls.BOTO3_RESOURCES[name] = resource
         return cls.BOTO3_RESOURCES[name]
-    
+
+    def __call__(self, event, context):
+        return self.handle(event, context)
+
     def handle(self, event, context):
         """Wrap this in a bare function to allow Lambda to call it"""
         import json

--- a/cfnlambda_util.py
+++ b/cfnlambda_util.py
@@ -32,7 +32,7 @@ def generate_request(request_type, resource_type, properties, response_url,
         response_url: A url or a tuple of (bucket, key) for S3. If key ends with
             'RANDOM', a random string replaces that.
     """
-    
+
     import uuid
     import boto3
 
@@ -57,15 +57,15 @@ def generate_request(request_type, resource_type, properties, response_url,
                 Params={
                     'Bucket': bucket,
                     'Key': key})
-    
+
     stack_id = stack_id or "arn:aws:cloudformation:us-west-2:EXAMPLE/stack-name/guid"
-    
+
     request_id = request_id or str(uuid.uuid4())
-    
+
     logical_resource_id = logical_resource_id or "MyLogicalResourceId"
-    
+
     physical_resource_id = physical_resource_id or logical_resource_id
-    
+
     event = {
            "RequestType" : request_type,
            "ResponseURL" : response_url,
@@ -75,17 +75,17 @@ def generate_request(request_type, resource_type, properties, response_url,
            "LogicalResourceId" : logical_resource_id,
            "ResourceProperties" : properties
            }
-    
+
     if request_type in ['Update', 'Delete']:
         if not physical_resource_id:
             raise RuntimeError('physical resource id not set for %s' % request_type)
         event['PhysicalResourceId'] = physical_resource_id
-    
+
     if request_type == 'Update':
         if not old_properties:
             raise RuntimeError('old properties not set for %s' % request_type)
         event['OldResourceProperties'] = old_properties
-    
+
     return event
 
 class MockLambdaContext(object):
@@ -96,7 +96,7 @@ class MockLambdaContext(object):
             timeout=3,
             start=None):
         import time, uuid
-        
+
         if start is None:
             start = time.time()
 


### PR DESCRIPTION
This PR adds a `__call__` method to the resource class so you can write handlers like this:

```
class MyThing(CloudFormationCustomResource):
    def create ...
        .....

handler = MyThing()
```

And use `handler` as the entry point instead of defining a pass-through function. 
